### PR TITLE
global: extension class to uppercase.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -42,3 +42,4 @@ recursive-include invenio_config_tugraz *.crt
 recursive-include invenio_config_tugraz *.json
 recursive-include invenio_config_tugraz *.key
 recursive-include invenio_config_tugraz *.xml
+recursive-include invenio_config_tugraz *.gitkeep

--- a/invenio_config_tugraz/__init__.py
+++ b/invenio_config_tugraz/__init__.py
@@ -8,8 +8,8 @@
 
 """invenio module that adds tugraz configs."""
 
-from .ext import invenioconfigtugraz
+from .ext import InvenioConfigTugraz
 from .generators import RecordIp
 from .version import __version__
 
-__all__ = ('__version__', 'invenioconfigtugraz', 'RecordIp')
+__all__ = ('__version__', 'InvenioConfigTugraz', 'RecordIp')

--- a/invenio_config_tugraz/ext.py
+++ b/invenio_config_tugraz/ext.py
@@ -13,7 +13,7 @@ from flask_babelex import gettext as _
 from . import config
 
 
-class invenioconfigtugraz(object):
+class InvenioConfigTugraz(object):
     """invenio-config-tugraz extension."""
 
     def __init__(self, app=None):

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     platforms='any',
     entry_points={
         'invenio_base.apps': [
-            'invenio_config_tugraz = invenio_config_tugraz:invenioconfigtugraz',
+            'invenio_config_tugraz = invenio_config_tugraz:InvenioConfigTugraz',
         ],
         'invenio_i18n.translations': [
             'messages = invenio_config_tugraz',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,14 @@ See https://pytest-invenio.readthedocs.io/ for documentation on which test
 fixtures are available.
 """
 
+import os
 import shutil
 import tempfile
 
 import pytest
 from flask import Flask
 from flask_babelex import Babel
+from invenio_db import InvenioDB, db
 
 from invenio_config_tugraz import InvenioConfigTugraz
 
@@ -31,13 +33,38 @@ def celery_config():
     return {}
 
 
-@pytest.fixture(scope='module')
-def create_app(instance_path):
-    """Application factory fixture."""
-    def factory(**config):
-        app = Flask('testapp', instance_path=instance_path)
-        app.config.update(**config)
-        Babel(app)
-        InvenioConfigTugraz(app)
-        return app
-    return factory
+@pytest.fixture()
+def create_app(request):
+    """Basic Flask application."""
+    instance_path = tempfile.mkdtemp()
+    app = Flask("testapp")
+    DB = os.getenv("SQLALCHEMY_DATABASE_URI", "sqlite://")
+    app.config.update(
+        INVENIO_CONFIG_TUGRAZ_SINGLE_IP=["127.0.0.1", "127.0.0.2"],
+        INVENIO_CONFIG_TUGRAZ_IP_RANGES=[
+            ["127.0.0.2", "127.0.0.99"], ["127.0.1.3", "127.0.1.5"]],
+        SQLALCHEMY_DATABASE_URI=DB,
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    Babel(app)
+    InvenioConfigTugraz(app)
+    InvenioDB(app)
+
+    with app.app_context():
+        db_url = str(db.engine.url)
+        if db_url != "sqlite://" and not database_exists(db_url):
+            create_database(db_url)
+        db.create_all()
+
+    def teardown():
+        with app.app_context():
+            db_url = str(db.engine.url)
+            db.session.close()
+            if db_url != "sqlite://":
+                drop_database(db_url)
+            shutil.rmtree(instance_path)
+
+    request.addfinalizer(teardown)
+    app.test_request_context().push()
+
+    return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ import pytest
 from flask import Flask
 from flask_babelex import Babel
 
-from invenio_config_tugraz import invenioconfigtugraz
+from invenio_config_tugraz import InvenioConfigTugraz
 
 
 @pytest.fixture(scope='module')
@@ -38,6 +38,6 @@ def create_app(instance_path):
         app = Flask('testapp', instance_path=instance_path)
         app.config.update(**config)
         Babel(app)
-        invenioconfigtugraz(app)
+        InvenioConfigTugraz(app)
         return app
     return factory

--- a/tests/test_invenio_config_tugraz.py
+++ b/tests/test_invenio_config_tugraz.py
@@ -10,7 +10,7 @@
 
 from flask import Flask
 
-from invenio_config_tugraz import invenioconfigtugraz
+from invenio_config_tugraz import InvenioConfigTugraz
 
 
 def test_version():
@@ -22,11 +22,11 @@ def test_version():
 def test_init():
     """Test extension initialization."""
     app = Flask('testapp')
-    ext = invenioconfigtugraz(app)
+    ext = InvenioConfigTugraz(app)
     assert 'invenio-config-tugraz' in app.extensions
 
     app = Flask('testapp')
-    ext = invenioconfigtugraz()
+    ext = InvenioConfigTugraz()
     assert 'invenio-config-tugraz' not in app.extensions
     ext.init_app(app)
     assert 'invenio-config-tugraz' in app.extensions


### PR DESCRIPTION
The extension class name should always start with uppercase.