### PR TITLE
all python files are now formated with black

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,45 +10,45 @@
 
 import os
 
-import sphinx.environment
+# import sphinx.environment
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Do not warn on external images.
-suppress_warnings = ['image.nonlocal_uri']
+suppress_warnings = ["image.nonlocal_uri"]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.coverage',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'invenio-config-tugraz'
-copyright = u'2020, Mojib Wali'
-author = u'Mojib Wali'
+project = u"invenio-config-tugraz"
+copyright = u"2020, Mojib Wali"
+author = u"Mojib Wali"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -58,11 +58,14 @@ author = u'Mojib Wali'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join(os.path.dirname(__file__), '..',
-                       'invenio_config_tugraz', 'version.py'),
-          'rt') as fp:
+with open(
+    os.path.join(
+        os.path.dirname(__file__), "..", "invenio_config_tugraz", "version.py"
+    ),
+    "rt",
+) as fp:
     exec(fp.read(), g)
-    version = g['__version__']
+    version = g["__version__"]
 
 # The full version, including alpha/beta/rc tags.
 release = version
@@ -76,9 +79,9 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -86,46 +89,46 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 html_theme_options = {
-    'description': 'invenio module that adds tugraz configs.',
-    'github_user': 'inveniosoftware',
-    'github_repo': 'invenio-config-tugraz',
-    'github_button': False,
-    'github_banner': True,
-    'show_powered_by': False,
-    'extra_nav_links': {
-        'invenio-config-tugraz@GitHub': 'https://github.com/mb-wali/invenio-config-tugraz',
-        'invenio-config-tugraz@PyPI': 'https://pypi.python.org/pypi/invenio-config-tugraz/',
-    }
+    "description": "invenio module that adds tugraz configs.",
+    "github_user": "inveniosoftware",
+    "github_repo": "invenio-config-tugraz",
+    "github_button": False,
+    "github_banner": True,
+    "show_powered_by": False,
+    "extra_nav_links": {
+        "invenio-config-tugraz@GitHub": "https://github.com/mb-wali/invenio-config-tugraz",
+        "invenio-config-tugraz@PyPI": "https://pypi.python.org/pypi/invenio-config-tugraz/",
+    },
 }
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -134,146 +137,148 @@ html_theme_options = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',
-        'searchbox.html',
-        'donate.html',
+    "**": [
+        "about.html",
+        "navigation.html",
+        "relations.html",
+        "searchbox.html",
+        "donate.html",
     ]
 }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'invenio-config-tugraz_namedoc'
+htmlhelp_basename = "invenio-config-tugraz_namedoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'invenio-config-tugraz.tex', u'invenio-config-tugraz Documentation',
-     u'Mojib Wali', 'manual'),
+    (
+        master_doc,
+        "invenio-config-tugraz.tex",
+        u"invenio-config-tugraz Documentation",
+        u"Mojib Wali",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -281,12 +286,17 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'invenio-config-tugraz', u'invenio-config-tugraz Documentation',
-     [author], 1)
+    (
+        master_doc,
+        "invenio-config-tugraz",
+        u"invenio-config-tugraz Documentation",
+        [author],
+        1,
+    )
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -295,30 +305,36 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'invenio-config-tugraz', u'invenio-config-tugraz Documentation',
-     author, 'invenio-config-tugraz', 'invenio module that adds tugraz configs.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "invenio-config-tugraz",
+        u"invenio-config-tugraz Documentation",
+        author,
+        "invenio-config-tugraz",
+        "invenio module that adds tugraz configs.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    "python": ("https://docs.python.org/", None),
     # TODO: Configure external documentation references, eg:
     # 'Flask-Admin': ('https://flask-admin.readthedocs.io/en/latest/', None),
 }
 
 # Autodoc configuraton.
-autoclass_content = 'both'
+autoclass_content = "both"

--- a/invenio_config_tugraz/__init__.py
+++ b/invenio_config_tugraz/__init__.py
@@ -12,4 +12,4 @@ from .ext import InvenioConfigTugraz
 from .generators import RecordIp
 from .version import __version__
 
-__all__ = ('__version__', 'InvenioConfigTugraz', 'RecordIp')
+__all__ = ("__version__", "InvenioConfigTugraz", "RecordIp")

--- a/invenio_config_tugraz/config.py
+++ b/invenio_config_tugraz/config.py
@@ -31,46 +31,47 @@ INVENIO_CONFIG_TUGRAZ_IP_RANGES =
 # ===========
 # See https://invenio-app.readthedocs.io/en/latest/configuration.html
 
-APP_ALLOWED_HOSTS = ['0.0.0.0',
-                     'localhost',
-                     '127.0.0.1',
-                     'invenio-dev01.tugraz.at',
-                     'invenio-test.tugraz.at'
-                     ]
+APP_ALLOWED_HOSTS = [
+    "0.0.0.0",
+    "localhost",
+    "127.0.0.1",
+    "invenio-dev01.tugraz.at",
+    "invenio-test.tugraz.at",
+]
 """Allowed Hosts"""
 
 APP_DEFAULT_SECURE_HEADERS = {
-    'content_security_policy': {
-        'default-src': [
+    "content_security_policy": {
+        "default-src": [
             "'self'",
-            'fonts.googleapis.com',
-            '*.gstatic.com',
-            'data:',
+            "fonts.googleapis.com",
+            "*.gstatic.com",
+            "data:",
             "'unsafe-inline'",
             "'unsafe-eval'",
             "blob:",
         ],
     },
-    'content_security_policy_report_only': False,
-    'content_security_policy_report_uri': None,
-    'force_file_save': False,
-    'force_https': True,
-    'force_https_permanent': False,
-    'frame_options': 'sameorigin',
-    'frame_options_allow_from': None,
-    'session_cookie_http_only': True,
-    'session_cookie_secure': True,
-    'strict_transport_security': True,
-    'strict_transport_security_include_subdomains': True,
-    'strict_transport_security_max_age': 31556926,  # One year in seconds
-    'strict_transport_security_preload': False,
+    "content_security_policy_report_only": False,
+    "content_security_policy_report_uri": None,
+    "force_file_save": False,
+    "force_https": True,
+    "force_https_permanent": False,
+    "frame_options": "sameorigin",
+    "frame_options_allow_from": None,
+    "session_cookie_http_only": True,
+    "session_cookie_secure": True,
+    "strict_transport_security": True,
+    "strict_transport_security_include_subdomains": True,
+    "strict_transport_security_max_age": 31556926,  # One year in seconds
+    "strict_transport_security_preload": False,
 }
 
 # Invenio-Mail
 # ===========
 # See https://invenio-mail.readthedocs.io/en/latest/configuration.html
 
-MAIL_SERVER = 'localhost'
+MAIL_SERVER = "localhost"
 """Domain ip where mail server is running."""
 
 SECURITY_EMAIL_SENDER = "info@invenio-test.tugraz.at"
@@ -117,23 +118,23 @@ when register.
 SSO_SAML_IDPS = {}
 """Configuration of IDPS. Actual values can be find in to invenio.cfg file"""
 
-SSO_SAML_DEFAULT_BLUEPRINT_PREFIX = '/shibboleth'
+SSO_SAML_DEFAULT_BLUEPRINT_PREFIX = "/shibboleth"
 """Base URL for the extensions endpoint."""
 
-SSO_SAML_DEFAULT_METADATA_ROUTE = '/metadata/<idp>'
+SSO_SAML_DEFAULT_METADATA_ROUTE = "/metadata/<idp>"
 """URL route for the metadata request."""
 """This is also SP entityID https://domain/shibboleth/metadata/<idp>"""
 
-SSO_SAML_DEFAULT_SSO_ROUTE = '/login/<idp>'
+SSO_SAML_DEFAULT_SSO_ROUTE = "/login/<idp>"
 """URL route for the SP login."""
 
-SSO_SAML_DEFAULT_ACS_ROUTE = '/authorized/<idp>'
+SSO_SAML_DEFAULT_ACS_ROUTE = "/authorized/<idp>"
 """URL route to handle the IdP login request."""
 
-SSO_SAML_DEFAULT_SLO_ROUTE = '/slo/<idp>'
+SSO_SAML_DEFAULT_SLO_ROUTE = "/slo/<idp>"
 """URL route for the SP logout."""
 
-SSO_SAML_DEFAULT_SLS_ROUTE = '/sls/<idp>'
+SSO_SAML_DEFAULT_SLS_ROUTE = "/sls/<idp>"
 """URL route to handle the IdP logout request."""
 
 # Invenio-accounts

--- a/invenio_config_tugraz/ext.py
+++ b/invenio_config_tugraz/ext.py
@@ -8,8 +8,6 @@
 
 """invenio module that adds tugraz configs."""
 
-# from flask_babelex import gettext as _
-
 from . import config
 
 

--- a/invenio_config_tugraz/ext.py
+++ b/invenio_config_tugraz/ext.py
@@ -8,7 +8,7 @@
 
 """invenio module that adds tugraz configs."""
 
-from flask_babelex import gettext as _
+# from flask_babelex import gettext as _
 
 from . import config
 
@@ -24,10 +24,10 @@ class InvenioConfigTugraz(object):
     def init_app(self, app):
         """Flask application initialization."""
         self.init_config(app)
-        app.extensions['invenio-config-tugraz'] = self
+        app.extensions["invenio-config-tugraz"] = self
 
     def init_config(self, app):
         """Initialize configuration."""
         for k in dir(config):
-            if k.startswith('INVENIO_CONFIG_TUGRAZ_'):
+            if k.startswith("INVENIO_CONFIG_TUGRAZ_"):
                 app.config.setdefault(k, getattr(config, k))

--- a/invenio_config_tugraz/generators.py
+++ b/invenio_config_tugraz/generators.py
@@ -209,6 +209,8 @@ class RecordIp(Generator):
         # Get user IP
         user_ip = request.remote_addr  # pragma: no cover
         # Checks if the user IP is among single IPs
-        if user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]:
+        if (
+            user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]
+        ):  # pragma: no cover
             return True  # pragma: no cover
         return False  # pragma: no cover

--- a/invenio_config_tugraz/generators.py
+++ b/invenio_config_tugraz/generators.py
@@ -202,13 +202,13 @@ class RecordIp(Generator):
         These filters consist of additive queries mapping to what the current
         user should be able to retrieve via search.
         """
-        return Q('match_all')
+        return Q("match_all")
 
     def check_permission(self):
         """Check for User IP address in config variable."""
         # Get user IP
         user_ip = request.remote_addr  # pragma: no cover
         # Checks if the user IP is among single IPs
-        if user_ip in current_app.config['INVENIO_CONFIG_TUGRAZ_SINGLE_IP']:
-            return True   # pragma: no cover
-        return False   # pragma: no cover
+        if user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]:
+            return True  # pragma: no cover
+        return False  # pragma: no cover

--- a/invenio_config_tugraz/generators.py
+++ b/invenio_config_tugraz/generators.py
@@ -209,8 +209,6 @@ class RecordIp(Generator):
         # Get user IP
         user_ip = request.remote_addr  # pragma: no cover
         # Checks if the user IP is among single IPs
-        if (
-            user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]
-        ):  # pragma: no cover
+        if user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]:  # pragma: no cover
             return True  # pragma: no cover
         return False  # pragma: no cover

--- a/invenio_config_tugraz/permissions.py
+++ b/invenio_config_tugraz/permissions.py
@@ -49,8 +49,12 @@ Using Custom Generator for a policy:
 Permissions for Invenio (RDM) Records.
 """
 
-from invenio_records_permissions.generators import Admin, AnyUser, \
-    AnyUserIfPublic, Disable, RecordOwners
+from invenio_records_permissions.generators import (
+    Admin,
+    AnyUser,
+    AnyUserIfPublic,
+    RecordOwners,
+)
 from invenio_records_permissions.policies.base import BasePermissionPolicy
 
 from .generators import RecordIp

--- a/invenio_config_tugraz/version.py
+++ b/invenio_config_tugraz/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_config_tugraz.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.2.1'
+__version__ = "0.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,20 @@ output-dir = invenio_config_tugraz/translations/
 [update_catalog]
 input-file = invenio_config_tugraz/translations/messages.pot
 output-dir = invenio_config_tugraz/translations/
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+select = C,E,F,W,B,B950
+ignore = E501
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88
+
+[pycodestyle]
+ignore = E203,E501

--- a/setup.py
+++ b/setup.py
@@ -12,35 +12,34 @@ import os
 
 from setuptools import find_packages, setup
 
-readme = open('README.rst').read()
-history = open('CHANGES.rst').read()
+readme = open("README.rst").read()
+history = open("CHANGES.rst").read()
 
 tests_require = [
-    'pytest-invenio>=1.4.0',
+    "pytest-invenio>=1.4.0",
 ]
 
 extras_require = {
-    'docs': [
-        'Sphinx>=1.5.1',
+    "docs": [
+        "Sphinx>=1.5.1",
     ],
-    'tests': tests_require,
+    "tests": tests_require,
 }
 
-extras_require['all'] = []
+extras_require["all"] = []
 for reqs in extras_require.values():
-    extras_require['all'].extend(reqs)
+    extras_require["all"].extend(reqs)
 
 setup_requires = [
-    'Babel>=1.3',
-    'pytest-runner>=3.0.0,<5',
+    "Babel>=1.3",
+    "pytest-runner>=3.0.0,<5",
 ]
 
 install_requires = [
-    'Flask-BabelEx>=0.9.4',
-    'elasticsearch_dsl>=7.2.1',
-    'invenio-rdm-records~=0.18.3',
-    'invenio_search>=1.3.1',
-
+    "Flask-BabelEx>=0.9.4",
+    "elasticsearch_dsl>=7.2.1",
+    "invenio-rdm-records~=0.18.3",
+    "invenio_search>=1.3.1",
 ]
 
 packages = find_packages()
@@ -48,33 +47,33 @@ packages = find_packages()
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('invenio_config_tugraz', 'version.py'), 'rt') as fp:
+with open(os.path.join("invenio_config_tugraz", "version.py"), "rt") as fp:
     exec(fp.read(), g)
-    version = g['__version__']
+    version = g["__version__"]
 
 setup(
-    name='invenio-config-tugraz',
+    name="invenio-config-tugraz",
     version=version,
     description=__doc__,
-    long_description=readme + '\n\n' + history,
-    keywords='invenio, config, Tu Graz',
-    license='MIT',
-    author='Mojib Wali',
-    author_email='mojib.wali@tugraz.at',
-    url='https://github.com/mb-wali/invenio-config-tugraz',
+    long_description=readme + "\n\n" + history,
+    keywords="invenio, config, Tu Graz",
+    license="MIT",
+    author="Mojib Wali",
+    author_email="mojib.wali@tugraz.at",
+    url="https://github.com/mb-wali/invenio-config-tugraz",
     packages=packages,
     zip_safe=False,
     include_package_data=True,
-    platforms='any',
+    platforms="any",
     entry_points={
-        'invenio_base.apps': [
-            'invenio_config_tugraz = invenio_config_tugraz:InvenioConfigTugraz',
+        "invenio_base.apps": [
+            "invenio_config_tugraz = invenio_config_tugraz:InvenioConfigTugraz",
         ],
-        'invenio_i18n.translations': [
-            'messages = invenio_config_tugraz',
+        "invenio_i18n.translations": [
+            "messages = invenio_config_tugraz",
         ],
-        'invenio_config.module': [
-            'invenio_config_tugraz = invenio_config_tugraz.config',
+        "invenio_config.module": [
+            "invenio_config_tugraz = invenio_config_tugraz.config",
         ],
     },
     extras_require=extras_require,
@@ -82,17 +81,17 @@ setup(
     setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Development Status :: 3 - Alpha',
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Development Status :: 3 - Alpha",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from invenio_db import InvenioDB, db
 from invenio_config_tugraz import InvenioConfigTugraz
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def celery_config():
     """Override pytest-invenio fixture.
 
@@ -42,7 +42,9 @@ def create_app(request):
     app.config.update(
         INVENIO_CONFIG_TUGRAZ_SINGLE_IP=["127.0.0.1", "127.0.0.2"],
         INVENIO_CONFIG_TUGRAZ_IP_RANGES=[
-            ["127.0.0.2", "127.0.0.99"], ["127.0.1.3", "127.0.1.5"]],
+            ["127.0.0.2", "127.0.0.99"],
+            ["127.0.1.3", "127.0.1.5"],
+        ],
         SQLALCHEMY_DATABASE_URI=DB,
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -6,12 +6,15 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
+"""Test Generators."""
+
 from invenio_config_tugraz.generators import RecordIp
 
 
 def test_recordip():
+    """Test Generator RecordIp."""
     generator = RecordIp()
 
     assert generator.needs() == []
     assert generator.excludes() == []
-    assert generator.query_filter().to_dict() == {'match_all': {}}
+    assert generator.query_filter().to_dict() == {"match_all": {}}

--- a/tests/test_invenio_config_tugraz.py
+++ b/tests/test_invenio_config_tugraz.py
@@ -16,17 +16,18 @@ from invenio_config_tugraz import InvenioConfigTugraz
 def test_version():
     """Test version import."""
     from invenio_config_tugraz import __version__
+
     assert __version__
 
 
 def test_init():
     """Test extension initialization."""
-    app = Flask('testapp')
+    app = Flask("testapp")
     ext = InvenioConfigTugraz(app)
-    assert 'invenio-config-tugraz' in app.extensions
+    assert "invenio-config-tugraz" in app.extensions
 
-    app = Flask('testapp')
+    app = Flask("testapp")
     ext = InvenioConfigTugraz()
-    assert 'invenio-config-tugraz' not in app.extensions
+    assert "invenio-config-tugraz" not in app.extensions
     ext.init_app(app)
-    assert 'invenio-config-tugraz' in app.extensions
+    assert "invenio-config-tugraz" in app.extensions


### PR DESCRIPTION
this close #22 

NOTE:
some configurations where necessary. flake8 line-length has to be set to 88
which is the default for black. but this was not enough some lines of black
where formated longer then 88 characters. found flake8-bugbear with B950.

with that and in combination with ignore=E501 it is possible to ignore long
lines, but if there are lines to long it will still point it out.

further also for isort some configuration was necessary

REFERENCES:
https://github.com/psf/black/blob/master/docs/compatible_configs.md#isort
https://github.com/psf/black/blob/master/docs/compatible_configs.md#flake8
https://github.com/PyCQA/flake8-bugbear#opinionated-warnings